### PR TITLE
Fixes Elytrat Feature lighting for 1.17

### DIFF
--- a/src/main/java/ladysnake/ratsmischief/client/render/entity/ElytratFeatureRenderer.java
+++ b/src/main/java/ladysnake/ratsmischief/client/render/entity/ElytratFeatureRenderer.java
@@ -2,6 +2,7 @@ package ladysnake.ratsmischief.client.render.entity;
 
 import ladysnake.ratsmischief.common.Mischief;
 import ladysnake.ratsmischief.common.entity.RatEntity;
+import net.minecraft.client.render.OverlayTexture;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.util.math.MatrixStack;
@@ -40,7 +41,7 @@ public class ElytratFeatureRenderer extends GeoLayerRenderer<RatEntity> {
                     matrixStackIn,
                     bufferIn,
                     bufferIn.getBuffer(RenderLayer.getEntityCutout(elytratLocation)),
-                    packedLightIn, packedLightIn, 1, 1, 1, 1);
+                    packedLightIn, OverlayTexture.DEFAULT_UV, 1, 1, 1, 1);
         }
     }
 }


### PR DESCRIPTION
BTW this fix is also compatible with 1.16, if you have any weird issues with it back there as well.