### PR TITLE
Balance changes

### DIFF
--- a/src/main/java/ladysnake/ratsmischief/common/entity/LivingEntityInterface.java
+++ b/src/main/java/ladysnake/ratsmischief/common/entity/LivingEntityInterface.java
@@ -1,0 +1,9 @@
+package ladysnake.ratsmischief.common.entity;
+
+public interface LivingEntityInterface {
+
+    int getRatCDs();
+
+    void incrementRatCDs(int increment);
+
+}

--- a/src/main/java/ladysnake/ratsmischief/common/entity/RatEntity.java
+++ b/src/main/java/ladysnake/ratsmischief/common/entity/RatEntity.java
@@ -89,7 +89,7 @@ public class RatEntity extends TameableEntity implements IAnimatable, Angerable 
     private static final TrackedData<Integer> ROCKET_TIME = DataTracker.registerData(RatEntity.class, TrackedDataHandlerRegistry.INTEGER);
     // Rat balancing variable
     // NOTE: Isn't linear. Equation: ActualDamage = OriginalDamage * (RAT_ATTACK_MODIFIER ^ lastAttack's ratCDs)
-    private final static double RAT_ATTACK_MODIFIER = 0.9F;
+    private final static double RAT_ATTACK_MODIFIER = 0.95;
     //Rat tool attack multipler
     private final static double TOOL_ATTACK_MODIFIER = 0.5;
     // Rat universal attack CD

--- a/src/main/java/ladysnake/ratsmischief/mixin/LivingEntityMixin.java
+++ b/src/main/java/ladysnake/ratsmischief/mixin/LivingEntityMixin.java
@@ -1,6 +1,7 @@
 package ladysnake.ratsmischief.mixin;
 
 import ladysnake.ratsmischief.common.Mischief;
+import ladysnake.ratsmischief.common.entity.LivingEntityInterface;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
@@ -13,7 +14,10 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(LivingEntity.class)
-abstract class LivingEntityMixin extends Entity {
+abstract class LivingEntityMixin extends Entity implements LivingEntityInterface {
+
+    private int ratCDs = 0;
+
     public LivingEntityMixin(EntityType<?> type, World world) {
         super(type, world);
     }
@@ -23,5 +27,13 @@ abstract class LivingEntityMixin extends Entity {
         if (adversary instanceof PlayerEntity && this.getUuid().equals("1b44461a-f605-4b29-a7a9-04e649d1981c")) {
             this.dropStack(new ItemStack(Mischief.RAT_MASK));
         }
+    }
+
+    public int getRatCDs() {
+        return ratCDs;
+    }
+
+    public void incrementRatCDs(int increment) {
+        ratCDs += increment;
     }
 }

--- a/src/main/java/ladysnake/ratsmischief/mixin/PlayerEntityMixin.java
+++ b/src/main/java/ladysnake/ratsmischief/mixin/PlayerEntityMixin.java
@@ -1,0 +1,25 @@
+package ladysnake.ratsmischief.mixin;
+
+import ladysnake.ratsmischief.common.entity.LivingEntityInterface;
+import ladysnake.ratsmischief.common.entity.RatEntity;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.damage.DamageSource;
+import net.minecraft.entity.player.PlayerEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(PlayerEntity.class)
+public class PlayerEntityMixin {
+
+    @Inject(method = "damageArmor", at = @At("HEAD"), cancellable = true)
+    public void capRatArmorDamage(DamageSource source, float amount, CallbackInfo ci) {
+        Entity attacker = source.getAttacker();
+        if (attacker instanceof RatEntity) {
+            ci.cancel();
+        }
+    }
+
+}

--- a/src/main/resources/ratsmischief.mixins.json
+++ b/src/main/resources/ratsmischief.mixins.json
@@ -5,7 +5,8 @@
   "mixins": [
     "CatEntityMixin",
     "FollowTargetGoalMixin",
-    "LivingEntityMixin"
+    "LivingEntityMixin",
+    "PlayerEntityMixin"
   ],
   "plugin": "ladysnake.ratsmischief.common.MischiefMixinConfigPlugin",
   "injectors": {


### PR DESCRIPTION

* Rat damage now has a non-linear curve depending on the previous rat cooldown stacks.

  Equation: ActualDamage = OriginalDamage * (RAT_ATTACK_MODIFIER ^ Rat cooldown stacks on target)
  
  RAT_ATTACK_MODIFIER is 0.95 by default.
  
  Rat cooldown stacks are given to a living entity when a rat attacks it and taken away when the rat dies or goes off cooldown.

* Rats can have strength, but do not gain increased damage from it

* Rat attack cooldown is increased depending on the swing speed of their equipped item

* Rats do half damage with an equipped tool/weapon.

* Rats do not do armor damage